### PR TITLE
[ccache] Use CMakeDeps on Linux

### DIFF
--- a/recipes/ccache/all/conanfile.py
+++ b/recipes/ccache/all/conanfile.py
@@ -1,8 +1,8 @@
 from conan import ConanFile
 from conan.tools.cmake import cmake_layout, CMake, CMakeToolchain, CMakeDeps
 from conan.errors import ConanInvalidConfiguration
-from conan.tools.files import export_conandata_patches, apply_conandata_patches, copy, get
-from conan.tools.build import cross_building, check_min_cppstd
+from conan.tools.files import copy, get
+from conan.tools.build import check_min_cppstd
 from conan.tools.scm import Version
 from conan.tools.microsoft import is_msvc
 import os
@@ -18,10 +18,9 @@ class CcacheConan(ConanFile):
         "compilation is being done again."
     )
     license = "GPL-3.0-or-later"
-    topics = ("ccache", "compiler-cache", "recompilation")
+    topics = ("compiler-cache", "recompilation", "cache", "compiler")
     homepage = "https://ccache.dev"
     url = "https://github.com/conan-io/conan-center-index"
-
     settings = "os", "arch", "compiler", "build_type"
     options = {
         "redis_storage_backend": [True, False],
@@ -58,9 +57,6 @@ class CcacheConan(ConanFile):
 
     def layout(self):
         cmake_layout(self, src_folder="src")
-
-    def export_sources(self):
-        export_conandata_patches(self)
 
     def requirements(self):
         self.requires("zstd/1.5.2")
@@ -102,18 +98,18 @@ class CcacheConan(ConanFile):
         tc.generate()
 
         deps = CMakeDeps(self)
-        deps.set_property("hiredislib", "cmake_target_name", "HIREDIS::HIREDIS")
+        deps.set_property("hiredis", "cmake_target_name", "HIREDIS::HIREDIS")
+        deps.set_property("hiredis", "cmake_find_mode", "module")
         deps.set_property("zstd", "cmake_target_name", "ZSTD::ZSTD")
         deps.generate()
 
     def build(self):
-        apply_conandata_patches(self)
         cmake = CMake(self)
         cmake.configure()
         cmake.build()
 
     def package(self):
-        copy(self, "GPL-*.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
+        copy(self, "*GPL-*.txt", src=self.source_folder, dst=os.path.join(self.package_folder, "licenses"))
         cmake = CMake(self)
         cmake.install()
 

--- a/recipes/ccache/all/test_package/conanfile.py
+++ b/recipes/ccache/all/test_package/conanfile.py
@@ -1,9 +1,15 @@
-from conans import ConanFile, tools
+from conan import ConanFile
+from conan.tools.build import can_run
 
 
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
+    generators = "VirtualBuildEnv"
+    test_type = "explicit"
+
+    def build_requirements(self):
+        self.tool_requires(self.tested_reference_str)
 
     def test(self):
-        if not tools.cross_building(self):
-            self.run("ccache --version", run_environment=True)
+        if can_run(self):
+            self.run("ccache --version")

--- a/recipes/ccache/all/test_v1_package/conanfile.py
+++ b/recipes/ccache/all/test_v1_package/conanfile.py
@@ -1,0 +1,9 @@
+from conans import ConanFile, tools
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+
+    def test(self):
+        if not tools.cross_building(self):
+            self.run("ccache --version", run_environment=True)


### PR DESCRIPTION
- Removed `export_conandata_patches` and `apply_conandata_patches` because there is no patch to be applied
- Copy all transitive licenses (LGPL and GPL)
- Validate package against Conan v2 testing interface
- Fix package name `hiredislib` to `hiredis`
- Consume CMake modules only, as requested by the upstream